### PR TITLE
docs: Fix a few typos

### DIFF
--- a/markdown.py
+++ b/markdown.py
@@ -1101,7 +1101,7 @@ class Markdown(object):
             # same script on the same server ran fine *except* under MT. I've spent
             # more time trying to figure out why this is happening than I'd like to
             # admit. My only guess, backed up by the fact that this workaround works,
-            # is that Perl optimizes the substition when it can figure out that the
+            # is that Perl optimizes the substitution when it can figure out that the
             # pattern will never change, and when this optimization isn't on, we run
             # afoul of the reaper. Thus, the slightly redundant code to that uses two
             # static s/// patterns rather than one conditional pattern.
@@ -1278,7 +1278,7 @@ class Markdown(object):
         #         <p>Just type <code>foo `bar` baz</code> at the prompt.</p>
         #     
         #       There's no arbitrary limit to the number of backticks you
-        #       can use as delimters. If you need three consecutive backticks
+        #       can use as delimiter. If you need three consecutive backticks
         #       in your code, use four for delimiters, etc.
         #
         #   *   You can use spaces to get literal backticks at the edges:

--- a/markdown.py
+++ b/markdown.py
@@ -1278,7 +1278,7 @@ class Markdown(object):
         #         <p>Just type <code>foo `bar` baz</code> at the prompt.</p>
         #     
         #       There's no arbitrary limit to the number of backticks you
-        #       can use as delimiter. If you need three consecutive backticks
+        #       can use as delimiters. If you need three consecutive backticks
         #       in your code, use four for delimiters, etc.
         #
         #   *   You can use spaces to get literal backticks at the edges:

--- a/static/js/showdown.js
+++ b/static/js/showdown.js
@@ -899,7 +899,7 @@ Attacklab.showdown.converter = function () {
 		//		 <p>Just type <code>foo `bar` baz</code> at the prompt.</p>
 		//	 
 		//	There's no arbitrary limit to the number of backticks you
-		//	can use as delimiter. If you need three consecutive backticks
+		//	can use as delimiters. If you need three consecutive backticks
 		//	in your code, use four for delimiters, etc.
 		//
 		//  *  You can use spaces to get literal backticks at the edges:

--- a/static/js/showdown.js
+++ b/static/js/showdown.js
@@ -899,7 +899,7 @@ Attacklab.showdown.converter = function () {
 		//		 <p>Just type <code>foo `bar` baz</code> at the prompt.</p>
 		//	 
 		//	There's no arbitrary limit to the number of backticks you
-		//	can use as delimters. If you need three consecutive backticks
+		//	can use as delimiter. If you need three consecutive backticks
 		//	in your code, use four for delimiters, etc.
 		//
 		//  *  You can use spaces to get literal backticks at the edges:


### PR DESCRIPTION
There are small typos in:
- markdown.py
- static/js/showdown.js

Fixes:
- Should read `delimiters` rather than `delimters`.
- Should read `substitution` rather than `substition`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md